### PR TITLE
Fix outdated option name for fixup-sam

### DIFF
--- a/src/duxhund/cli.clj
+++ b/src/duxhund/cli.clj
@@ -62,9 +62,9 @@
    ["-o" "--output BAM" "Output BAM path"]])
 
 (defn fixup-sam [argv]
-  (when-let [{:keys [input cache output]}
+  (when-let [{:keys [input saved-seqs output]}
              (get-opts! (parse-opts argv fixup-sam-opts))]
-    (dux/fixup-sam input cache output)
+    (dux/fixup-sam input saved-seqs output)
     0))
 
 (def sub-commands


### PR DESCRIPTION
Sorry, I forgot to rename a local binding `cache` to `saved-seqs` in #1 (8f5b366), which causes a NPE when running the `fixup-sam` subcommand.