### PR TITLE
Update fusionfusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+- Changed dependent fusionfusion's branch to fix/inserted-seq
 
 ## [0.1.0] - 2021-10-19
 - First release

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.chrovis/duxhund "0.1.1-SNAPSHOT"
+(defproject com.chrovis/duxhund "0.1.1"
   :description "DUX4 fusions finder"
   :url "https://github.com/chrovis/duxhund"
   :license {:name "GPL-3.0-or-later"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.chrovis/duxhund "0.1.1"
+(defproject com.chrovis/duxhund "0.1.2-SNAPSHOT"
   :description "DUX4 fusions finder"
   :url "https://github.com/chrovis/duxhund"
   :license {:name "GPL-3.0-or-later"


### PR DESCRIPTION
This PR updates the dependent fusionfusion branch to [`fix/inserted-seq`](https://github.com/chrovis-genomon/fusionfusion/compare/devel...chrovis-genomon:fix/inserted-seq) from [`feature/short-range-chimera-filter2`](https://github.com/chrovis-genomon/fusionfusion/compare/devel...chrovis-genomon:feature/short-range-chimera-filter2).

The `fix/inserted-seq` branch is `devel` + chrovis-genomon/fusionfusion#9 + `feature/ecr` and the `feature/short-range-chimera-filter2` branch is equivalent to `devel` + chrovis-genomon/fusionfusion#8 + `feature/ecr`, so this change effectively replaces chrovis-genomon/fusionfusion#8 with chrovis-genomon/fusionfusion#9.

Once this PR is merged, I will add the tag `0.1.1` to 013dc3347207e511701c82a4c7eb2257ba4265ad.