### PR TITLE
Update fusionfusion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir --upgrade awscli==1.19.112
 RUN wget -q https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 \
  && tar xf bwa-0.7.17.tar.bz2 \
  && cd bwa-0.7.17 \
- && make \
+ && make CFLAGS='-fcommon -Wall -Wno-unused-function -O2' \
  && mv bwa /usr/local/bin/bwa \
  && cd .. \
  && rm -rf bwa-0.7.17

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/chrovis/duxhund"
   :license {:name "GPL-3.0-or-later"
             :url "https://www.gnu.org/licenses/gpl-3.0.html"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-sub-command "0.6.0"]
                  [cljam "0.8.2"]]
   :repl-options {:init-ns duxhund.core}

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.gnu.org/licenses/gpl-3.0.html"}
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-sub-command "0.6.0"]
-                 [cljam "0.8.2"]]
+                 [cljam "0.8.3"]]
   :repl-options {:init-ns duxhund.core}
   :main duxhund.cli
   :profiles {:dev

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.chrovis/duxhund "0.1.2"
+(defproject com.chrovis/duxhund "0.1.3-SNAPSHOT"
   :description "DUX4 fusions finder"
   :url "https://github.com/chrovis/duxhund"
   :license {:name "GPL-3.0-or-later"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.chrovis/duxhund "0.1.2-SNAPSHOT"
+(defproject com.chrovis/duxhund "0.1.2"
   :description "DUX4 fusions finder"
   :url "https://github.com/chrovis/duxhund"
   :license {:name "GPL-3.0-or-later"


### PR DESCRIPTION
This PR updates fusionfusion to the [`fix/inserted-seq2`](https://github.com/chrovis-genomon/fusionfusion/compare/devel...chrovis-genomon:fusionfusion:fix/inserted-seq2) branch, which is the latest (forked) `devel` plus the change for chrovis-genomon/fusionfusion#9.

The PR also includes a small tweak for the value of `CFLAGS` to ensure bwa builds successfully. This is a workaround for the issue that [the latest released BWA no longer builds properly with recent versions of GCC](https://github.com/lh3/bwa/issues/314) (>= 10), and it will probably be necessary until the next version of BWA is out. (Btw, I dropped the `-g` option from [the original `CFLAGS`](https://github.com/lh3/bwa/blob/b56db225480b9f6242b7d2b22b46b61d6ba48e73/Makefile#L3) since it's apparently unnecessary and might be harmful for performance.)