### PR TITLE
Fix errors that occur when handling “incomplete" alignment triplets

### DIFF
--- a/src/duxhund/core.clj
+++ b/src/duxhund/core.clj
@@ -161,10 +161,8 @@
             (->> (cigar/parse (:cigar a))
                  (keep (fn [[n op]] (when (= op \M) n)))
                  (apply +)))]
-    (if (and (nil? a3)
-             (or (nil? a2)
-                 (not= (flag/r1r2 (:flag a1))
-                       (flag/r1r2 (:flag a2)))))
+    (if (not= (flag/r1r2 (:flag a1))
+              (flag/r1r2 (:flag a2)))
       alns
       (let [flag-inherited (flag/encoded #{:multiple :properly-aligned
                                            :next-unmapped :next-reversed})
@@ -190,6 +188,7 @@
                                     (bit-shift-left r1r2 6)))
              (cond-> cutoff (update :cigar fixup-cigar cutoff))))
        (partition-by :qname)
+       (filter (fn [[_a1 _a2 a3]] a3))
        (mapcat fixup-flag)))
 
 (defn fixup-sam [in-sam saved-seqs-edn out-sam]

--- a/test/duxhund/core_test.clj
+++ b/test/duxhund/core_test.clj
@@ -61,8 +61,11 @@
   (is (= [["qname1:chr4:12357" 99 "12M8S" "AAAAATGCATGCATGCCCCC" "ABBCCCDDDDEEEEEFFFFF"]
           ["qname1:chr4:12357" 355 "12S8M" "AAAAATGCATGCATGCCCCC" "ABBCCCDDDDEEEEEFFFFF"]
           ["qname1:chr4:12357" 147 "20M" "AATTGGCCAATTGGCCATGC" "ABBCCCDDDDEEEEEFFFFF"]
-          ["qname3:chr10:12350" 64 "5S9M6S" "AAAAATGCATGCATGCCCCC" "ABBCCCDDDDEEEEEFFFFF"]
-          ["qname3:chr10:12350" 144 "20M" "AATTGGCCAATTGGCCATGC" "ABBCCCDDDDEEEEEFFFFF"]
+          ;; These alignments will be filtered out because they are incomplete,
+          ;; which means one or more alignments in the same triplet was not
+          ;; mapped as a primary alignment
+          ;; ["qname3:chr10:12350" 64 "5S9M6S" "AAAAATGCATGCATGCCCCC" "ABBCCCDDDDEEEEEFFFFF"]
+          ;; ["qname3:chr10:12350" 144 "20M" "AATTGGCCAATTGGCCATGC" "ABBCCCDDDDEEEEEFFFFF"]
           ["qname3:chr10:12359" 419 "14S6M" "GCATGGCCAATTGGCCAATT" "FFFFFEEEEEDDDDCCCBBA"]
           ["qname3:chr10:12359" 163 "11M9S" "GCATGGCCAATTGGCCAATT" "FFFFFEEEEEDDDDCCCBBA"]
           ["qname3:chr10:12359" 83 "20M" "GGGGGCATGCATGCATTTTT" "FFFFFEEEEEDDDDCCCBBA"]


### PR DESCRIPTION
When analyzing some samples with duxhund, I ran into errors like the following (at the fusionfusion phase):

```
Traceback (most recent call last):
File "/usr/local/bin/fusionfusion", line 33, in <module>
sys.exit(load_entry_point('fusionfusion==0.5.2', 'console_scripts', 'fusionfusion')())
File "/usr/local/lib/python3.10/dist-packages/fusionfusion-0.5.2-py3.10.egg/fusionfusion/__init__.py", line 10, in main
File "/usr/local/lib/python3.10/dist-packages/fusionfusion-0.5.2-py3.10.egg/fusionfusion/run.py", line 150, in fusionfusion_main
File "/usr/local/lib/python3.10/dist-packages/fusionfusion-0.5.2-py3.10.egg/fusionfusion/parseJunctionInfo.py", line 594, in parseJuncInfo_STAR
IndexError: string index out of range
```

After digging into the cause, it turned out that SAM files generated by duxhund can contain blank lines in some cases. This seems to be due to the fact that while duxhund fixes up alignment flags, [it unintentionally inserts `nil` into the resulting alignments](https://github.com/chrovis/duxhund/blob/7e3e9cfabfed18eb341b119f8e3899b8a8a3d4ae/src/duxhund/core.clj#L164-L176) when the alignment triplet is *incomplete*, that is, one or more alignments in the alignment triplet weren't mapped as a primary alignment.

This PR resolves the above error by filtering out the incomplete alignment triplets completely from the results. Since the incomplete triplets have been dropped at the succeeding fusionfusion phase anyway, this fix should not affect the whole analysis result.

