### PR TITLE
Explicitly install leiningen on ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ jobs:
         java-version: 11
         architecture: x64
 
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
+
     - name: Cache m2 repository
       uses: actions/cache@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM chrovis-genomon/fusionfusion:${BASE_IMAGE_TAG}
 WORKDIR /opt
 COPY --from=builder /opt/duxhund/target/duxhund.jar /opt/duxhund/duxhund.jar
 COPY --from=builder /opt/duxhund/duxhund*.sh /usr/local/bin/
-RUN pip install --no-cache-dir --upgrade awscli==1.19.112
+RUN pip install --no-cache-dir --upgrade awscli==1.36.36
 RUN wget -q https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 \
  && tar xf bwa-0.7.17.tar.bz2 \
  && cd bwa-0.7.17 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ WORKDIR /opt
 COPY --from=builder /opt/duxhund/target/duxhund.jar /opt/duxhund/duxhund.jar
 COPY --from=builder /opt/duxhund/duxhund*.sh /usr/local/bin/
 RUN pip install --no-cache-dir --upgrade awscli==1.36.36
-RUN wget -q https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 \
- && tar xf bwa-0.7.17.tar.bz2 \
- && cd bwa-0.7.17 \
+RUN wget -q https://github.com/lh3/bwa/archive/refs/tags/v0.7.18.tar.gz \
+ && tar xf v0.7.18.tar.gz \
+ && cd bwa-0.7.18 \
  && make CFLAGS='-fcommon -Wall -Wno-unused-function -O2' \
  && mv bwa /usr/local/bin/bwa \
  && cd .. \
- && rm -rf bwa-0.7.17
+ && rm -rf bwa-0.7.18
 RUN wget -q https://github.com/samtools/samtools/releases/download/1.13/samtools-1.13.tar.bz2 \
  && tar xf samtools-1.13.tar.bz2 \
  && cd samtools-1.13 \


### PR DESCRIPTION
@athos Thank you for submitting https://github.com/chrovis/cljam/pull/331 ! 🙏 
I have made the same modifications as `chrovis/cljam` for this repository.

I have also upgraded awscli to [`1.36.36`](https://pypi.org/project/awscli/1.36.36/#history) since [installing `1.19.112` fails now](https://github.com/chrovis/duxhund/actions/runs/12684747429/job/35353932734#step:5:2198).

[`bwa` has been upgraded](https://github.com/lh3/bwa/compare/v0.7.17...v0.7.18) too because I want to test builds on my local arm64 machine. I believe it does not contain any changes of alignment results.